### PR TITLE
Suppress Expect header and use Buzz Browser

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,9 +8,9 @@ composer install jeremymarc/akamai-php-client
 ## Usage
 ```php
 
-$curl = new Curl;
+$browser = new \Buzz\Browser(new \Buzz\Client\Curl());
 
-$client = new Client($curl, $clientToken, $clientSecret, $accessToken, $baseUrl);
+$client = new Client($browser, $clientToken, $clientSecret, $accessToken, $baseUrl);
 $resp = $client->checkQueueLength();
 echo $resp->queueLength;
 ```

--- a/src/Akamai/Client/Client.php
+++ b/src/Akamai/Client/Client.php
@@ -4,7 +4,7 @@ namespace Akamai\Client;
 
 use Akamai\Client\Exception\HttpException;
 use Akamai\Client\Exception\LogicException;
-use Buzz\Client\ClientInterface;
+use Buzz\Browser;
 use Buzz\Message\Request;
 use Buzz\Message\Response;
 use Buzz\Listener\BasicAuthListener;
@@ -12,9 +12,9 @@ use Buzz\Listener\BasicAuthListener;
 class Client
 {
     /**
-     * @var ClientInterface
+     * @var Browser
      */
-    protected $httpClient;
+    protected $browser;
 
     /**
      * @var string
@@ -41,9 +41,9 @@ class Client
      */
     protected $headersToSign;
 
-    public function __construct(ClientInterface $httpClient, $clientToken, $clientSecret, $accessToken, $baseUrl)
+    public function __construct(Browser $browser, $clientToken, $clientSecret, $accessToken, $baseUrl)
     {
-        $this->httpClient = $httpClient;
+        $this->browser = $browser;
         $this->clientToken = $clientToken;
         $this->clientSecret = $clientSecret;
         $this->accessToken = $accessToken;
@@ -108,7 +108,7 @@ class Client
         // $listener = new BasicAuthListener($this->username, $this->password);
         // $listener->preSend($request);
 
-        $this->httpClient->send($request, $response);
+        $this->browser->send($request, $response);
 
         return $this->getResult($response);
     }

--- a/src/Akamai/Client/Client.php
+++ b/src/Akamai/Client/Client.php
@@ -104,6 +104,7 @@ class Client
         $nonce = uniqid();
         $authToken = $this->makeAuthHeader($request, $timestamp, $nonce);
         $request->addHeader("Authorization: " . $authToken);
+        $request->addHeader("Expect:");
 
         // $listener = new BasicAuthListener($this->username, $this->password);
         // $listener->preSend($request);


### PR DESCRIPTION
We were experiencing some issues with sending purge requests. This turned out to be because Curl adds `Expect: 100-continue` headers under some circumstances. To fix this issue, we've started suppressing Expect headers. We also modified the library to use a Buzz browser instead of a Buzz client, in order to be able to use listeners for debugging. If possible, we'd like to contribute this upstream.
